### PR TITLE
Allow some pin events in ShouldNotPin

### DIFF
--- a/src/main/java/me/escoffier/loom/loomunit/LoomUnitExtension.java
+++ b/src/main/java/me/escoffier/loom/loomunit/LoomUnitExtension.java
@@ -129,7 +129,8 @@ public class LoomUnitExtension implements BeforeAllCallback, AfterAllCallback, B
 		}
 
 		if (notpin != null) {
-			if (!pinEvents.isEmpty()) {
+
+			if (!pinEvents.isEmpty() && pinEvents.size() > notpin.atMost()) {
 				throw new AssertionError("The test " + extensionContext.getDisplayName() + " was expected to NOT pin the carrier thread"
 						+ ", but we collected " + pinEvents.size() + " event(s)\n" + dump(pinEvents));
 			}

--- a/src/main/java/me/escoffier/loom/loomunit/ShouldNotPin.java
+++ b/src/main/java/me/escoffier/loom/loomunit/ShouldNotPin.java
@@ -8,9 +8,12 @@ import java.lang.annotation.Target;
 /**
  * Marker indicating that the test method should not pin the carrier thread.
  * If, during the execution of the test, a virtual thread pins the carrier thread, the test fails.
+ * However occasional pin can still be allowed by setting {@code atMost} value
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface ShouldNotPin {
+
+    int atMost() default 0;
 
 }

--- a/src/test/java/me/escoffier/loom/loomunit/snippets/CodeUnderTest.java
+++ b/src/test/java/me/escoffier/loom/loomunit/snippets/CodeUnderTest.java
@@ -5,9 +5,15 @@ import java.util.concurrent.CountDownLatch;
 public class CodeUnderTest {
 
     void pin() {
-        CountDownLatch latch = new CountDownLatch(1);
-        CodeUnderTest pinning = new CodeUnderTest();
-        Thread.ofVirtual().start(() -> pinning.callSynchronizedMethod(latch));
+        pin(1);
+    }
+
+    void pin(int count) {
+        CountDownLatch latch = new CountDownLatch(count);
+        for (int i = 0; i < count; i++) {
+            CodeUnderTest pinning = new CodeUnderTest();
+            Thread.ofVirtual().start(() -> pinning.callSynchronizedMethod(latch));
+        }
         try {
             latch.await();
         } catch (InterruptedException e) {

--- a/src/test/java/me/escoffier/loom/loomunit/snippets/LoomUnitExampleTest.java
+++ b/src/test/java/me/escoffier/loom/loomunit/snippets/LoomUnitExampleTest.java
@@ -23,6 +23,12 @@ public class LoomUnitExampleTest {
     }
 
     @Test
+    @ShouldNotPin(atMost = 1)
+    public void testThatShouldNotPinButOneTime() {
+        codeUnderTest.pin(1);
+    }
+
+    @Test
     @ShouldPin(atMost = 1)
     public void testThatShouldPinAtMostOnce() {
         codeUnderTest.pin();


### PR DESCRIPTION
I know loom-unit is a part of quarkus now, maybe the addition would
also added there, if the pull request is accepted

`ShouldNotPin `annotation doesn't allow any pin events to happen. However, in some
situations, one still wants to allow an occasional pin to happen.

Adding `atMost `parameter to `ShouldNotPin `makes it possible.

Background: I have a test with about 600 requests using virtual threads. Most of the time
no pin event is observed. However once in a while, it still happens and 1 pin event makes the test fail